### PR TITLE
replace remaining pcmset62 call with pcmset22

### DIFF
--- a/X68Sound/opm.h
+++ b/X68Sound/opm.h
@@ -1420,7 +1420,7 @@ inline int Opm::GetPcm(void *buf, int ndata) {
 	PcmBuf = (short (*)[2])buf;
 	PcmBufPtr=0;
 	if (WaveOutSamp == 44100 || WaveOutSamp == 48000) {
-		pcmset62(ndata);
+		pcmset22(ndata);
 	} else {
 		pcmset22(ndata);
 	}


### PR DESCRIPTION
commit a420f5b didnt change out this reference to pcmset62, so any program that used Opm::GetPcm at 44.1khz or 48khz didnt sound right, this just corrects that small oversight.